### PR TITLE
Better naming of file in case '/' is a backup location

### DIFF
--- a/backup-scripts/amazon-cloud-drive/acd-backup.sh
+++ b/backup-scripts/amazon-cloud-drive/acd-backup.sh
@@ -162,7 +162,12 @@ do
   # Generating name for the file
   echo "$loc" > .yodabackup_tmp
   sed -i 's/\//./g' .yodabackup_tmp
-  FILENAME=$(cat .yodabackup_tmp)
+  if [ $loc == '/' ]
+  then
+    FILENAME="ROOT"
+  else
+    FILENAME=$(cat .yodabackup_tmp)
+  fi
   rm .yodabackup_tmp
   TARNAME="$HOST-$DATE-$FILENAME.tar.gz"
   TARLOC="$TMPDIR/$TARNAME"


### PR DESCRIPTION
If the backup location is /, the name would have been empty as slashes get removed. This PR changes that so it is properly indicated.